### PR TITLE
Properly logs errors as errors

### DIFF
--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -267,7 +267,7 @@ module Google
         # @yield [nil, err] if block given
         # @raise [StandardError] if no block
         def error(err, rethrow: false, &block)
-          logger.debug { sprintf('Error - %s', PP.pp(err, '')) }
+          logger.error { sprintf('Error - %s', PP.pp(err, '')) }
           if err.is_a?(HTTPClient::BadResponseError)
             begin
               res = err.res


### PR DESCRIPTION
Atm almost all logs from the core api are debug logs. The default level for the logger is set to warn meaning, we see almost nothing at the beginning and it gets to verbose as soon as we reach the debug level.

This is not practical to debug real errors that why I'm proposing to change the level of this error log to error from debug